### PR TITLE
Delete policies/devopsdays-event-rules.md

### DIFF
--- a/policies/devopsdays-event-rules.md
+++ b/policies/devopsdays-event-rules.md
@@ -1,9 +1,0 @@
-# Rules for DevOpsDays Events
-
-Every devopsdays event is different, but there are a few rules to keep in mind if you’d like your event to be listed on devopsdays.org:
-
-- Inclusiveness and respect for differences are core devops values, and we invite you to help us make each devopsdays event a place that is welcoming and respectful to all participants. Your event will need to have a code of conduct.
-- These are community events, so your event must have an open call for proposals and accept registrations from the general public. Internal devops events focused on a specific organization or curated events with all speakers privately selected are wonderful and we encourage them, but they won’t be listed as “devopsdays” events on this site.
-- You must look for ways to create opportunities for conversation and collaboration during the event. Traditionally, this is done through the use of open spaces, but it can take many forms. Other examples include (but are not limited to) attendee-led roundtables, office hours, birds-of-a-feather groups, Q&A sessions, and workshops with robust attendee interaction.
-- These events are not for individual or corporate profit. If you have money left over, you can use it for your next event, to help other devopsdays events directly or via sending participants, or for charity. The global core team can (and will) accept donations in order to help us cover costs such as DNS and web hosting, but only from conferences that use Conference Ops. In any case, leftover money should not be making its way into anyone’s pockets.
-- Sponsors are much appreciated for their financial assistance, and they are welcome to participate in devopsdays events. They are never given attendee contact info by a devopsdays event’s organizers, nor are they allowed to purchase speaking slots for talks or ignites at a devopsdays.


### PR DESCRIPTION
**RFC Period Ends**: 21 November 2024
**Voting Period Begins**: 21 November 2024
**Voting Period Ends**: 28 November 2024
**Proposal Description**: This content is duplicated in https://github.com/devopsdays/devopsdays-web/blob/main/content/page/organizing.md and should not exist canonically in two places, imho. I propose the source of truth be that public repository, which is actively maintained, and not this private one, which nobody really looks at.